### PR TITLE
Corrected UTF8 Text-File Import

### DIFF
--- a/src/viz/management/commands/harald.test
+++ b/src/viz/management/commands/harald.test
@@ -1,0 +1,1 @@
+Das ist nur ein primitiver Test!

--- a/src/viz/management/commands/harald.test
+++ b/src/viz/management/commands/harald.test
@@ -1,1 +1,0 @@
-Das ist nur ein primitiver Test!

--- a/src/viz/management/commands/import_base.py
+++ b/src/viz/management/commands/import_base.py
@@ -16,28 +16,28 @@ class Command(BaseCommand):
 		}
 
 		# import elections
-		elections = json.loads(self.open_file('data/setup/elections.json'))
+		elections = self.open_jsonfile('data/setup/elections.json')
 		self.import_elections(elections, config)
 
 		# import regional electoral districts
-		reds = json.loads(self.open_file('data/setup/regional-electoral-districts_20170101.json'))
+		reds = self.open_jsonfile('data/setup/regional-electoral-districts_20170101.json')
 		self.import_reds(reds, config)
 
 		# import parties
-		parties = json.loads(self.open_file('data/setup/parties.json'))
+		parties = self.open_jsonfile('data/setup/parties.json')
 		self.import_parties(parties, config)
 		
 		# import lists
-		lists = json.loads(self.open_file('data/setup/lists.json'))
+		lists = self.open_jsonfile('data/setup/lists.json')
 		self.import_lists(lists, config)
 
 		# import states and districts
-		states_districts = json.loads(self.open_file('data/setup/states-to-districts_20170101.json'))
+		states_districts = self.open_jsonfile('data/setup/states-to-districts_20170101.json')
 		self.import_states_districts(states_districts, config)
 
 		# import municipalities
-		municipalities = json.loads(self.open_file('data/setup/municipalities_20170101_2.json'))
-		muns2reds = json.loads(self.open_file('data/setup/municipality2red_20170101.json'))
+		municipalities = self.open_jsonfile('data/setup/municipalities_20170101_2.json')
+		muns2reds = self.open_jsonfile('data/setup/municipality2red_20170101.json')
 		self.import_municipalities(municipalities, muns2reds, config)
 
 	def open_file(self, filename,):
@@ -46,7 +46,7 @@ class Command(BaseCommand):
 		"""
 
 		try:
-			with open(filename) as data_file:
+			with open(filename, encoding='utf-8') as data_file:
 				return data_file.read()
 		except IOError:
 			print('Error: can\'t find file or read data')
@@ -54,7 +54,7 @@ class Command(BaseCommand):
 	def open_jsonfile(self, filename):
 
 		try:
-			data = json.loads(self.open_file(filename))
+			data = json.loads(open(filename, encoding='utf-8-sig').read())
 			return data
 		except JSONDecodeError:
 			print('Error: File is not valid JSON.')


### PR DESCRIPTION
 Added UTF8 Import for Textfiles (JSON and Plain-Textfiles)

Unter Windows, Python und Posgres wurden die Daten mit falsche Encodierung und die Datenbank geschrieben. Ich habe das Script so umgebaut, dass die Textdateien explizit mit UTF8-Codierung eingelesen werden, der Import funktioniert nun Korrekt.


